### PR TITLE
Add filename and path on edit view

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import { remote, ipcRenderer } from 'electron'
 import { jsx, Styled } from 'theme-ui'
 import { render } from 'react-dom'
 import { Editor, serializer, stringifyMDX } from '@blocks/editor'
-import { Folder, FileText } from 'react-feather'
+import { Folder, FileText, ArrowLeft } from 'react-feather'
 import debounce from 'lodash.debounce'
 
 import Layout from './layout'
@@ -56,6 +56,8 @@ const App = () => {
   }, [openFilePathname])
 
   if (openFilePathname && openFileContents) {
+    const parentDir = getParentDirectory(openFilePathname)
+    
     return (
       <Styled.root
         css={{
@@ -66,6 +68,30 @@ const App = () => {
           marginTop: '40px'
         }}
         >
+        <Styled.a
+          css={{
+            display: 'flex',
+            alignItems: 'center',
+            cursor: 'pointer',
+            marginBottom: '2px'
+          }}
+          onClick={() => {
+            handleFileListSelection(parentDir)
+          }}
+        >
+          <ArrowLeft />
+          <span sx={{ ml: 2 }}>Back</span>
+        </Styled.a>
+        <Styled.p
+          css={{
+            display: 'flex',
+            alignItems: 'center',
+            marginBottom: '20px'
+          }}
+        >
+            <FileText />
+            <span sx={{ ml: 2 }}>{openFilePathname}</span>
+        </Styled.p>
         <Editor
           initialValue={openFileContents}
           onChange={({ value }) => {


### PR DESCRIPTION
Here's what this new feature looks like:

![Shot 2019-07-24 at 07 57 41](https://user-images.githubusercontent.com/30328854/61772559-7a75be00-adea-11e9-83b9-83845cddebba.jpg)

Closes #3

P.S. Do you like the above `<- Back`, or should it be something like:

![Shot 2019-07-24 at 07 59 54](https://user-images.githubusercontent.com/30328854/61772599-95483280-adea-11e9-9108-6bba0b1988e3.jpg)

(`ArrowLeftCircle` icon instead of `ArrowLeft`)